### PR TITLE
Mention Airports DLC compatibility in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ He was so kind as to license his code under the MIT license for us, so if you li
 The core code for the match-making logic has been mostly completely rewritten, but with pcfantasy's original idea and design in mind.
 <br /><br />
 
+![This mod is compatible with the Airports DLC and the accompanying base game patch](https://i.imgur.com/NWy2c0D.png)
 
 ## What it does
 The vanilla transfer managers handles service requests and goods transfers by matching highest priority orders (incoming and outgoing) first, regardless of distance.


### PR DESCRIPTION
Why make people read the comments to see if it's compatible

Preview: https://github.com/NotAProton/MoreEffectiveTransfer/tree/NotAProton-patch-readme#readme I think it looks kind of weird but that's the best place I could find to put it, you can do some re-ordering if you want
I took the image off of [TMPE's steam page](https://steamcommunity.com/sharedfiles/filedetails/?id=1637663252), Bloody Penguin is using it for their [mods](https://steamcommunity.com/sharedfiles/filedetails/?id=502750307) as well


Also, thanks for continuing it :)